### PR TITLE
로그아웃 기능 구현 완료

### DIFF
--- a/src/main/java/com/chzzk/cushion/global/config/SecurityConfig.java
+++ b/src/main/java/com/chzzk/cushion/global/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userService(customOAuth2UserService))
-                        .successHandler(customSuccessHandler) // customSuccessHandler 등록 -> 로그인이 성공하면 쿠키에 담김
+                        .successHandler(customSuccessHandler)
                 );
 
         return http.build();

--- a/src/main/java/com/chzzk/cushion/global/exception/ErrorCode.java
+++ b/src/main/java/com/chzzk/cushion/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     EXPIRED_JWT_TOKEN(UNAUTHORIZED, "만료된 토큰 입니다."),
     INVALID_JWT_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다"),
     UNAUTHORIZED_REISSUE_TOKEN(UNAUTHORIZED, "로그아웃 상태에서 토큰을 재발급 받을 수 없습니다."),
+    NEED_LOGIN(UNAUTHORIZED, "로그인이 필요합니다."),
 
     // 403
 

--- a/src/main/java/com/chzzk/cushion/member/application/MemberService.java
+++ b/src/main/java/com/chzzk/cushion/member/application/MemberService.java
@@ -1,0 +1,38 @@
+package com.chzzk.cushion.member.application;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.view.RedirectView;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    public RedirectView logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+
+        if (authentication != null) {
+            new SecurityContextLogoutHandler().logout(request, response, authentication);
+        }
+
+        clearCookies(request, response);
+        return new RedirectView("/"); // 로그아웃 후 리디렉션할 URL
+    }
+
+    private void clearCookies(HttpServletRequest request, HttpServletResponse response) {
+        for (Cookie cookie : request.getCookies()) {
+            cookie.setValue("");
+            cookie.setPath("/");
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
+        }
+    }
+}

--- a/src/main/java/com/chzzk/cushion/member/presentation/MemberController.java
+++ b/src/main/java/com/chzzk/cushion/member/presentation/MemberController.java
@@ -1,0 +1,36 @@
+package com.chzzk.cushion.member.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+@Tag(name = "member", description = "회원 API")
+public class MemberController {
+
+    @GetMapping("/login/oauth2/naver")
+    @Operation(summary = "소셜 로그인_네이버", description = "네이버 소셜 로그인을 위한 URL을 리다이렉트 합니다.")
+    public RedirectView loginToNaver() {
+        return new RedirectView("/oauth2/authorization/naver");
+    }
+
+    @GetMapping("/login/oauth2/kakao")
+    @Operation(summary = "소셜 로그인_카카오", description = "카카오 소셜 로그인을 위한 URL을 리다이렉트 합니다.")
+    public RedirectView loginToKakao() {
+        return new RedirectView("/oauth2/authorization/kakao");
+    }
+
+    @GetMapping("/login/oauth2/google")
+    @Operation(summary = "소셜 로그인_구글", description = "구글 소셜 로그인을 위한 URL을 리다이렉트 합니다.")
+    public RedirectView loginToGoogle() {
+        return new RedirectView("/oauth2/authorization/google");
+    }
+}

--- a/src/main/java/com/chzzk/cushion/member/presentation/MemberController.java
+++ b/src/main/java/com/chzzk/cushion/member/presentation/MemberController.java
@@ -1,10 +1,15 @@
 package com.chzzk.cushion.member.presentation;
 
+import com.chzzk.cushion.member.application.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
@@ -15,6 +20,8 @@ import org.springframework.web.servlet.view.RedirectView;
 @RequestMapping("/members")
 @Tag(name = "member", description = "회원 API")
 public class MemberController {
+
+    private final MemberService memberService;
 
     @GetMapping("/login/oauth2/naver")
     @Operation(summary = "소셜 로그인_네이버", description = "네이버 소셜 로그인을 위한 URL을 리다이렉트 합니다.")
@@ -32,5 +39,11 @@ public class MemberController {
     @Operation(summary = "소셜 로그인_구글", description = "구글 소셜 로그인을 위한 URL을 리다이렉트 합니다.")
     public RedirectView loginToGoogle() {
         return new RedirectView("/oauth2/authorization/google");
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "소셜 로그인한 계정을 로그아웃합니다.")
+    public RedirectView logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        return memberService.logout(request, response, authentication);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 소셜 로그인 URI 컨트롤러에 명시화
- [x] 로그아웃 기능 구현

## 💡 자세한 설명
### 크롬 테스트 완료

## 로그아웃 기능 구현

로그아웃 시, postman에서 테스트할 경우 redirect 될 페이지가 현재 존재하지 않아 에러가 납니다.
다만, 크롬에서 테스트 시 쿠키에 담긴 토큰들이 지워짐을 확인했습니다.
(원래 로그아웃 요청은 POST 요청이지만, 테스트시에만 임시로 GET 요청으로 수정했습니다.)
![image](https://github.com/user-attachments/assets/1569a0df-1687-4e27-b979-db82fd0d8581)
![image](https://github.com/user-attachments/assets/cb734ff0-5e51-42a1-b713-8d1fc02e2372)

closes #7 
