### PR TITLE
소셜 로그인 후 타 API에서 회원 미인증 문제 해결 완료

### DIFF
--- a/src/main/java/com/chzzk/cushion/global/config/WebConfig.java
+++ b/src/main/java/com/chzzk/cushion/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.chzzk.cushion.global.config;
+
+import com.chzzk.cushion.global.jwt.ApiMemberArgumentResolver;
+import com.chzzk.cushion.global.jwt.JwtTokenProvider;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new ApiMemberArgumentResolver(jwtTokenProvider));
+    }
+}

--- a/src/main/java/com/chzzk/cushion/global/jwt/ApiMemberArgumentResolver.java
+++ b/src/main/java/com/chzzk/cushion/global/jwt/ApiMemberArgumentResolver.java
@@ -41,6 +41,7 @@ public class ApiMemberArgumentResolver implements HandlerMethodArgumentResolver 
         String token = jwtTokenProvider.resolveToken(request);
         jwtTokenProvider.validateToken(token);
         String email = jwtTokenProvider.getPayload(token);
+        log.debug("Resolved email from token: {}", email);
 
         return new ApiMember(email);
     }

--- a/src/main/java/com/chzzk/cushion/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/chzzk/cushion/global/jwt/JwtTokenProvider.java
@@ -50,7 +50,7 @@ public class JwtTokenProvider {
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expireDate)
-                .signWith(getSigningKey(), SignatureAlgorithm.HS512)
+                .signWith(SignatureAlgorithm.HS512, secretKey)
                 .compact();
     }
 
@@ -68,7 +68,7 @@ public class JwtTokenProvider {
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expireDate)
-                .signWith(getSigningKey(), SignatureAlgorithm.HS512)
+                .signWith(SignatureAlgorithm.HS512, secretKey)
                 .compact();
     }
 
@@ -93,7 +93,7 @@ public class JwtTokenProvider {
     }
 
     public Authentication getAuthenticationByToken(String token) {
-        String userPrincipal = Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody().getSubject();
+        String userPrincipal = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody().getSubject();
         UserDetails userDetails = myUserDetailService.loadUserByUsername(userPrincipal);
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
@@ -107,13 +107,13 @@ public class JwtTokenProvider {
     }
 
     public String getPayload(String token) {
-        return Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody().getSubject();
+        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody().getSubject();
     }
 
     public boolean validateToken(String token) {
         try {
-            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token);
-            return !claims.getBody().getExpiration().before(new Date());
+            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
@@ -124,7 +124,6 @@ public class JwtTokenProvider {
             throw new IllegalArgumentException("Authentication is required");
         }
     }
-
     public String reissueAccessToken(String refreshToken, Long memberId) {
         validateToken(refreshToken);
         Authentication authentication = getAuthenticationByToken(refreshToken);

--- a/src/main/java/com/chzzk/cushion/global/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/com/chzzk/cushion/global/oauth2/dto/CustomOAuth2User.java
@@ -34,6 +34,6 @@ public class CustomOAuth2User implements OAuth2User {
 
     @Override
     public String getName() {
-        return getUsername();
+        return oauth2Dto.getEmail();
     }
 }

--- a/src/main/java/com/chzzk/cushion/member/application/MyUserDetailService.java
+++ b/src/main/java/com/chzzk/cushion/member/application/MyUserDetailService.java
@@ -17,8 +17,8 @@ public class MyUserDetailService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public CustomUserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(username)
+    public CustomUserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new CushionException(ErrorCode.NOT_FOUND_MEMBER));
         return new CustomUserDetails(member);
     }

--- a/src/main/java/com/chzzk/cushion/member/domain/Member.java
+++ b/src/main/java/com/chzzk/cushion/member/domain/Member.java
@@ -42,6 +42,6 @@ public class Member extends BaseTimeEntity {
         return chatRooms.stream()
                 .filter(chatRoom -> chatRoom.getId().equals(roomId))
                 .findFirst()
-                .orElseThrow(() -> new CushionException(ErrorCode.NOT_FOUND_MEMBER));
+                .orElseThrow(() -> new CushionException(ErrorCode.NOT_FOUND_CHAT_ROOT));
     }
 }

--- a/src/main/java/com/chzzk/cushion/member/dto/ApiMember.java
+++ b/src/main/java/com/chzzk/cushion/member/dto/ApiMember.java
@@ -14,11 +14,13 @@ import static com.chzzk.cushion.global.exception.ErrorCode.NOT_FOUND_MEMBER;
 @AllArgsConstructor
 public class ApiMember {
 
-    private String username;
+    private String email;
 
     public Member toMember(MemberRepository memberRepository) {
-        log.info("username={}", username);
-        return memberRepository.findByEmail(username)
+        log.info("username={}", email);
+        Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new CushionException(NOT_FOUND_MEMBER));
+        log.info("Found member: {}", member);
+        return member;
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 에러 해결

## 💡 자세한 설명
원인은 다음과 같습니다.

1. `ArgumentResolver` 를 동작하게 하는 `WebConfig` 클래스 부재

2. `Member`의 `findChatRoomById()` 메서드 동작 시 사전에 chat_room 테이블에 해당 값이 없음

 `WebConfig` 클래스를 작성하고, chat_room 테이블에 필요한 값을 넣어줌으로서 해결했습니다.

closes #20
