### PR TITLE
문체 변환, 채팅방 목록 조회, 채팅방 검색 기능 구현 완료

### DIFF
--- a/src/main/java/com/chzzk/cushion/chatroom/application/ChatRoomService.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/application/ChatRoomService.java
@@ -42,8 +42,9 @@ public class ChatRoomService {
         chatRoomRepository.save(chatRoom);
     }
 
-    public List<ChatRoomResponse> findAll() {
-        return chatRoomRepository.findAllOrderByLastUsedAt();
+    public List<ChatRoomResponse> findAll(ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
+        return chatRoomRepository.findAllOrderByLastUsedAt(member);
     }
 
     @Transactional

--- a/src/main/java/com/chzzk/cushion/chatroom/application/SearchChatRoomService.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/application/SearchChatRoomService.java
@@ -2,6 +2,9 @@ package com.chzzk.cushion.chatroom.application;
 
 import com.chzzk.cushion.chatroom.domain.repository.ChatRoomRepository;
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse;
+import com.chzzk.cushion.member.domain.Member;
+import com.chzzk.cushion.member.domain.MemberRepository;
+import com.chzzk.cushion.member.dto.ApiMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,8 +15,10 @@ import java.util.List;
 public class SearchChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final MemberRepository memberRepository;
 
-    public List<ChatRoomResponse> searchByTitle(String query) {
-        return chatRoomRepository.searchByTitle(query);
+    public List<ChatRoomResponse> searchByTitle(ApiMember apiMember, String query) {
+        Member member = apiMember.toMember(memberRepository);
+        return chatRoomRepository.searchByTitle(member, query);
     }
 }

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
@@ -49,6 +49,9 @@ public class ChatRoom extends BaseTimeEntity {
 
     public void addMessage(Message message) {
         this.messages.add(message);
-        this.lastUsedAt = LocalDateTime.now();
+    }
+
+    public void updateLastUsedAt(LocalDateTime lastUsedAt) {
+        this.lastUsedAt = lastUsedAt;
     }
 }

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
@@ -49,5 +49,6 @@ public class ChatRoom extends BaseTimeEntity {
 
     public void addMessage(Message message) {
         this.messages.add(message);
+        this.lastUsedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryCustom.java
@@ -9,5 +9,5 @@ public interface ChatRoomRepositoryCustom {
 
     List<ChatRoomResponse> findAllOrderByLastUsedAt(Member member);
 
-    List<ChatRoomResponse> searchByTitle(String query);
+    List<ChatRoomResponse> searchByTitle(Member member, String query);
 }

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryCustom.java
@@ -1,12 +1,13 @@
 package com.chzzk.cushion.chatroom.domain.repository;
 
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse;
+import com.chzzk.cushion.member.domain.Member;
 
 import java.util.List;
 
 public interface ChatRoomRepositoryCustom {
 
-    List<ChatRoomResponse> findAllOrderByLastUsedAt();
+    List<ChatRoomResponse> findAllOrderByLastUsedAt(Member member);
 
     List<ChatRoomResponse> searchByTitle(String query);
 }

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryImpl.java
@@ -3,13 +3,9 @@ package com.chzzk.cushion.chatroom.domain.repository;
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse;
 import com.chzzk.cushion.chatroom.dto.QChatRoomResponse;
 import com.chzzk.cushion.member.domain.Member;
-import com.querydsl.core.types.dsl.DateTimePath;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.chzzk.cushion.chatroom.domain.QChatRoom.chatRoom;
@@ -28,13 +24,9 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
                 ))
                 .from(chatRoom)
                 .join(message).on(chatRoom.id.eq(message.chatRoom.id))
-                .where(chatRoom.member.id.eq(member.getId()), toDate(chatRoom.lastUsedAt).eq(toDate(message.createdAt)))
+                .where(chatRoom.member.id.eq(member.getId()), chatRoom.lastUsedAt.eq(message.createdAt))
                 .orderBy(chatRoom.lastUsedAt.desc())
                 .fetch();
-    }
-
-    private StringTemplate toDate(DateTimePath<LocalDateTime> localDateTime) {
-        return Expressions.stringTemplate("DATE({0})", localDateTime);
     }
 
     @Override

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryImpl.java
@@ -30,14 +30,16 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
     }
 
     @Override
-    public List<ChatRoomResponse> searchByTitle(String query) {
+    public List<ChatRoomResponse> searchByTitle(Member member, String query) {
         return queryFactory
                 .select(new QChatRoomResponse(
                         chatRoom.id, chatRoom.partnerName, chatRoom.partnerRel, message.content, chatRoom.lastUsedAt
                 ))
                 .from(chatRoom)
                 .join(message).on(chatRoom.id.eq(message.chatRoom.id))
-                .where(chatRoom.lastUsedAt.eq(message.createdAt), chatRoom.title.contains(query))
+                .where(chatRoom.member.id.eq(member.getId()),
+                        chatRoom.lastUsedAt.eq(message.createdAt),
+                        chatRoom.title.contains(query))
                 .orderBy(chatRoom.lastUsedAt.desc())
                 .fetch();
     }

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/repository/ChatRoomRepositoryImpl.java
@@ -2,9 +2,14 @@ package com.chzzk.cushion.chatroom.domain.repository;
 
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse;
 import com.chzzk.cushion.chatroom.dto.QChatRoomResponse;
+import com.chzzk.cushion.member.domain.Member;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.chzzk.cushion.chatroom.domain.QChatRoom.chatRoom;
@@ -16,16 +21,20 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<ChatRoomResponse> findAllOrderByLastUsedAt() {
+    public List<ChatRoomResponse> findAllOrderByLastUsedAt(Member member) {
         return queryFactory
                 .select(new QChatRoomResponse(
                         chatRoom.id, chatRoom.partnerName, chatRoom.partnerRel, message.content, chatRoom.lastUsedAt
                 ))
                 .from(chatRoom)
                 .join(message).on(chatRoom.id.eq(message.chatRoom.id))
-                .where(chatRoom.lastUsedAt.eq(message.createdAt))
+                .where(chatRoom.member.id.eq(member.getId()), toDate(chatRoom.lastUsedAt).eq(toDate(message.createdAt)))
                 .orderBy(chatRoom.lastUsedAt.desc())
                 .fetch();
+    }
+
+    private StringTemplate toDate(DateTimePath<LocalDateTime> localDateTime) {
+        return Expressions.stringTemplate("DATE({0})", localDateTime);
     }
 
     @Override

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/repository/MessageRepository.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/repository/MessageRepository.java
@@ -1,0 +1,7 @@
+package com.chzzk.cushion.chatroom.domain.repository;
+
+import com.chzzk.cushion.chatroom.domain.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/src/main/java/com/chzzk/cushion/chatroom/dto/ChatRoomResponse.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/dto/ChatRoomResponse.java
@@ -31,7 +31,7 @@ public class ChatRoomResponse {
         this.roomId = roomId;
         this.partnerName = partnerName;
         this.relationship = relationship.getLabel();
-        this.lastMessage = lastMessage;
+        this.lastMessage = lastMessage.replace("\n", "");
         this.lastUsedAt = lastUsedAt;
     }
 }

--- a/src/main/java/com/chzzk/cushion/chatroom/presentation/ChatRoomController.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/presentation/ChatRoomController.java
@@ -9,6 +9,7 @@ import com.chzzk.cushion.chatroom.dto.ChatRoomResponse;
 import com.chzzk.cushion.global.utils.AuthPrincipal;
 import com.chzzk.cushion.member.dto.ApiMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -31,8 +32,8 @@ public class ChatRoomController {
 
     @Operation(summary = "채팅방 목록 조회", description = "채팅방 목록을 조회합니다.")
     @GetMapping
-    public List<ChatRoomResponse> findAllChatRooms() {
-        return chatRoomService.findAll();
+    public List<ChatRoomResponse> findAllChatRooms(@Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        return chatRoomService.findAll(apiMember);
     }
 
     @Operation(summary = "채팅방 상세 조회", description = "채팅방 상세 페이지를 조회합니다.")

--- a/src/main/java/com/chzzk/cushion/chatroom/presentation/SearchChatRoomController.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/presentation/SearchChatRoomController.java
@@ -2,7 +2,10 @@ package com.chzzk.cushion.chatroom.presentation;
 
 import com.chzzk.cushion.chatroom.application.SearchChatRoomService;
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse;
+import com.chzzk.cushion.global.utils.AuthPrincipal;
+import com.chzzk.cushion.member.dto.ApiMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +25,8 @@ public class SearchChatRoomController {
 
     @Operation(summary = "채팅방 검색", description = "채팅방 제목(상대방 이름 및 관계)을 통해 채팅방을 검색합니다.")
     @GetMapping
-    public List<ChatRoomResponse> searchChatRoomsByTitle(@RequestParam String query) {
-        return searchChatRoomService.searchByTitle(query);
+    public List<ChatRoomResponse> searchChatRoomsByTitle(@Parameter(hidden = true) @AuthPrincipal ApiMember apiMember,
+                                                         @RequestParam String query) {
+        return searchChatRoomService.searchByTitle(apiMember, query);
     }
 }

--- a/src/main/java/com/chzzk/cushion/style/application/ChangeStyleService.java
+++ b/src/main/java/com/chzzk/cushion/style/application/ChangeStyleService.java
@@ -200,9 +200,17 @@ public class ChangeStyleService {
         requestData.put("seed", 0);
 
         String resultMessage = clovaStudioApiExecutor.execute(requestData);
-        messageRepository.save(createMessageEntity(chatRoom, resultMessage));
+        Message messageEntity = saveMessage(chatRoom, resultMessage);
+        chatRoom.updateLastUsedAt(messageEntity.getCreatedAt());
 
         return resultMessage;
+    }
+
+    private Message saveMessage(ChatRoom chatRoom, String resultMessage) {
+        Message messageEntity = createMessageEntity(chatRoom, resultMessage);
+        messageRepository.save(messageEntity);
+        messageRepository.flush();
+        return messageEntity;
     }
 
     private Message createMessageEntity(ChatRoom chatRoom, String content) {

--- a/src/main/java/com/chzzk/cushion/style/application/ChangeStyleService.java
+++ b/src/main/java/com/chzzk/cushion/style/application/ChangeStyleService.java
@@ -24,7 +24,7 @@ public class ChangeStyleService {
 
     @Transactional
     public String changeStyle(ApiMember apiMember, long roomId, String userMessage) {
-        String systemMessage = "- 당신의 역할은 사용자의 문체를 부드럽고 정중하게 변환해주는 것입니다. \n" +
+        String promptSystemMessage = "- 당신의 역할은 사용자의 문체를 부드럽고 정중하게 변환해주는 것입니다. \n" +
                 "- 사용자가 입력한 문장의 의도와 맥락을 정확히 파악하여 최대한 가깝게 전달해야 합니다.\n" +
                 "- 어떻게 말해야 할지 어려워하는 사용자를 돕기 위해 문체를 변환해주세요.\n" +
                 "- 사용자가 실제 대화할 상대방의 성향과 관계를 고려하여 적절한 문체로 변환해 주세요.\n" +
@@ -178,11 +178,11 @@ public class ChangeStyleService {
 
         JSONObject system = new JSONObject();
         system.put("role", "system");
-        system.put("content", systemMessage);
+        system.put("content", promptSystemMessage);
 
         JSONObject user = new JSONObject();
         user.put("role", "user");
-        user.put("content", userMessage);
+        user.put("content", createPromptUserMessage(member, chatRoom, userMessage));
 
         JSONArray presetText = new JSONArray();
         presetText.add(system);
@@ -204,6 +204,17 @@ public class ChangeStyleService {
         chatRoom.updateLastUsedAt(messageEntity.getCreatedAt());
 
         return resultMessage;
+    }
+
+    private String createPromptUserMessage(Member member, ChatRoom chatRoom, String message) {
+        StringBuffer sb = new StringBuffer();
+        sb.append("사용자 이름: ").append(member.getRealName()).append("\n");
+        sb.append("사용자 소속: ").append(member.getAffiliation()).append("\n");
+        sb.append("사용자 직무: ").append(member.getJob()).append("\n");
+        sb.append("상대방 이름: ").append(chatRoom.getPartnerName()).append("\n");
+        sb.append("상대방 관계: ").append(chatRoom.getPartnerRel().getLabel()).append("\n");
+        sb.append("문장: ").append(message).append("\n");
+        return sb.toString();
     }
 
     private Message saveMessage(ChatRoom chatRoom, String resultMessage) {

--- a/src/main/java/com/chzzk/cushion/style/application/ChangeStyleService.java
+++ b/src/main/java/com/chzzk/cushion/style/application/ChangeStyleService.java
@@ -3,6 +3,7 @@ package com.chzzk.cushion.style.application;
 import com.chzzk.cushion.chatroom.domain.ChatRoom;
 import com.chzzk.cushion.chatroom.domain.Message;
 import com.chzzk.cushion.chatroom.domain.SenderType;
+import com.chzzk.cushion.chatroom.domain.repository.MessageRepository;
 import com.chzzk.cushion.member.domain.Member;
 import com.chzzk.cushion.member.domain.MemberRepository;
 import com.chzzk.cushion.member.dto.ApiMember;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +20,9 @@ public class ChangeStyleService {
 
     private final ClovaStudioApiExecutor clovaStudioApiExecutor;
     private final MemberRepository memberRepository;
+    private final MessageRepository messageRepository;
 
+    @Transactional
     public String changeStyle(ApiMember apiMember, long roomId, String userMessage) {
         String systemMessage = "- 당신의 역할은 사용자의 문체를 부드럽고 정중하게 변환해주는 것입니다. \n" +
                 "- 사용자가 입력한 문장의 의도와 맥락을 정확히 파악하여 최대한 가깝게 전달해야 합니다.\n" +
@@ -196,16 +200,18 @@ public class ChangeStyleService {
         requestData.put("seed", 0);
 
         String resultMessage = clovaStudioApiExecutor.execute(requestData);
-        chatRoom.addMessage(createMessageEntity(chatRoom, resultMessage));
+        messageRepository.save(createMessageEntity(chatRoom, resultMessage));
 
         return resultMessage;
     }
 
     private Message createMessageEntity(ChatRoom chatRoom, String content) {
-        return Message.builder()
+        Message message = Message.builder()
                 .chatRoom(chatRoom)
                 .content(content)
                 .senderType(SenderType.BOT)
                 .build();
+        chatRoom.addMessage(message);
+        return message;
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 문체 변환 기능 구현 완료
- [x] 채팅방 목록 조회 기능 구현 완료
- [x] 채팅방 검색 기능 구현 완료

## 💡 자세한 설명
### 문제 변환 기능
변환할 문장만 전달하면 사용자와 상대방 정보에 맞춰 변환되도록 구현했습니다.

### 채팅방 목록 조회 기능
![image](https://github.com/user-attachments/assets/4ca3e90e-9526-412a-a076-f5f04542742a)
![image](https://github.com/user-attachments/assets/dfe137d2-0dab-47f5-b7a4-5a4c611d4f1f)
자신이 생성한 채팅방을 최근 사용일 기준 내림차순으로 반환하도록 구현했습니다.

### 채팅방 검색 기능
이전에 구현했던 채팅방 검색 기능에 회원 관련 로직을 추가하여 자신이 생성한 채팅방만 반환되도록 했습니다.

closes #18 
