### PR TITLE
채팅방 메시지에 cascade 적용

### DIFF
--- a/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
@@ -44,7 +44,7 @@ public class ChatRoom extends BaseTimeEntity {
 
     private LocalDateTime lastUsedAt;
 
-    @OneToMany(mappedBy = "chatRoom")
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
     private List<Message> messages = new ArrayList<>();
 
     public void addMessage(Message message) {


### PR DESCRIPTION
## 💡 작업 내용
- [x] 채팅방 메시지에 cacade 적용

## 💡 자세한 설명
<img width="1669" alt="image" src="https://github.com/user-attachments/assets/6a7b5af9-70b9-473f-882d-2f6ecef26924">
채팅방 삭제 시 연관관계 매핑되어 있는 메시지로 인해 문제가 발생했습니다.

cascade 적용을 통해 이 문제를 해결했습니다.

closes #50 
