### PR TITLE
중복 이메일 등록 시 에러 해결 완료

### DIFF
--- a/src/main/java/com/chzzk/cushion/global/jwt/ApiMemberArgumentResolver.java
+++ b/src/main/java/com/chzzk/cushion/global/jwt/ApiMemberArgumentResolver.java
@@ -43,6 +43,7 @@ public class ApiMemberArgumentResolver implements HandlerMethodArgumentResolver 
         String email = jwtTokenProvider.getPayload(token);
         log.debug("Resolved email from token: {}", email);
 
-        return new ApiMember(email);
+        Long userId = jwtTokenProvider.getMemberId(token);
+        return new ApiMember(email, userId);
     }
 }

--- a/src/main/java/com/chzzk/cushion/global/jwt/ApiMemberArgumentResolver.java
+++ b/src/main/java/com/chzzk/cushion/global/jwt/ApiMemberArgumentResolver.java
@@ -43,7 +43,7 @@ public class ApiMemberArgumentResolver implements HandlerMethodArgumentResolver 
         String email = jwtTokenProvider.getPayload(token);
         log.debug("Resolved email from token: {}", email);
 
-        Long userId = jwtTokenProvider.getMemberId(token);
-        return new ApiMember(email, userId);
+        Long memberId = jwtTokenProvider.getMemberId(token);
+        return new ApiMember(email, memberId);
     }
 }

--- a/src/main/java/com/chzzk/cushion/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/chzzk/cushion/global/jwt/JwtTokenProvider.java
@@ -96,8 +96,10 @@ public class JwtTokenProvider {
     }
 
     public Authentication getAuthenticationByToken(String token) {
-        String userPrincipal = Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody().getSubject();
-        UserDetails userDetails = myUserDetailService.loadUserByUsername(userPrincipal);
+        Claims claims = Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody();
+        String userPrincipal = claims.getSubject();
+        Long userId = getMemberId(token);
+        UserDetails userDetails = myUserDetailService.loadUserByIdAndUsername(userId, userPrincipal);
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
@@ -142,5 +144,10 @@ public class JwtTokenProvider {
             return customUserDetails.getMemberId();
         }
         return null;
+    }
+
+    public Long getMemberId(String token) {
+        Claims claims = Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody();
+        return claims.get("memberId", Long.class);
     }
 }

--- a/src/main/java/com/chzzk/cushion/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/chzzk/cushion/global/jwt/JwtTokenProvider.java
@@ -98,8 +98,8 @@ public class JwtTokenProvider {
     public Authentication getAuthenticationByToken(String token) {
         Claims claims = Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody();
         String userPrincipal = claims.getSubject();
-        Long userId = getMemberId(token);
-        UserDetails userDetails = myUserDetailService.loadUserByIdAndUsername(userId, userPrincipal);
+        Long memberId = getMemberId(token);
+        UserDetails userDetails = myUserDetailService.loadUserByIdAndUsername(memberId, userPrincipal);
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 

--- a/src/main/java/com/chzzk/cushion/member/application/MyUserDetailService.java
+++ b/src/main/java/com/chzzk/cushion/member/application/MyUserDetailService.java
@@ -22,4 +22,10 @@ public class MyUserDetailService implements UserDetailsService {
                 .orElseThrow(() -> new CushionException(ErrorCode.NOT_FOUND_MEMBER));
         return new CustomUserDetails(member);
     }
+
+    public CustomUserDetails loadUserByIdAndUsername(Long userId, String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByIdAndEmail(userId, email)
+                .orElseThrow(() -> new CushionException(ErrorCode.NOT_FOUND_MEMBER));
+        return new CustomUserDetails(member);
+    }
 }

--- a/src/main/java/com/chzzk/cushion/member/application/MyUserDetailService.java
+++ b/src/main/java/com/chzzk/cushion/member/application/MyUserDetailService.java
@@ -23,8 +23,8 @@ public class MyUserDetailService implements UserDetailsService {
         return new CustomUserDetails(member);
     }
 
-    public CustomUserDetails loadUserByIdAndUsername(Long userId, String email) throws UsernameNotFoundException {
-        Member member = memberRepository.findByIdAndEmail(userId, email)
+    public CustomUserDetails loadUserByIdAndUsername(Long memberId, String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByIdAndEmail(memberId, email)
                 .orElseThrow(() -> new CushionException(ErrorCode.NOT_FOUND_MEMBER));
         return new CustomUserDetails(member);
     }

--- a/src/main/java/com/chzzk/cushion/member/domain/MemberRepository.java
+++ b/src/main/java/com/chzzk/cushion/member/domain/MemberRepository.java
@@ -8,4 +8,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Member findByUsername(String username);
+
+    Optional<Member> findByIdAndEmail(Long id, String email);
 }

--- a/src/main/java/com/chzzk/cushion/member/dto/ApiMember.java
+++ b/src/main/java/com/chzzk/cushion/member/dto/ApiMember.java
@@ -15,11 +15,11 @@ import static com.chzzk.cushion.global.exception.ErrorCode.NOT_FOUND_MEMBER;
 public class ApiMember {
 
     private String email;
-    private Long userId;
+    private Long memberId;
 
     public Member toMember(MemberRepository memberRepository) {
         log.info("username={}", email);
-        Member member = memberRepository.findByIdAndEmail(userId, email)
+        Member member = memberRepository.findByIdAndEmail(memberId, email)
                 .orElseThrow(() -> new CushionException(NOT_FOUND_MEMBER));
         log.info("Found member: {}", member);
         return member;

--- a/src/main/java/com/chzzk/cushion/member/dto/ApiMember.java
+++ b/src/main/java/com/chzzk/cushion/member/dto/ApiMember.java
@@ -15,10 +15,11 @@ import static com.chzzk.cushion.global.exception.ErrorCode.NOT_FOUND_MEMBER;
 public class ApiMember {
 
     private String email;
+    private Long userId;
 
     public Member toMember(MemberRepository memberRepository) {
         log.info("username={}", email);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByIdAndEmail(userId, email)
                 .orElseThrow(() -> new CushionException(NOT_FOUND_MEMBER));
         log.info("Found member: {}", member);
         return member;


### PR DESCRIPTION
## 💡 작업 내용
- [x] 중복 이메일 처리

## 💡 자세한 설명
### postman 테스트 완료
kakao 소셜 로그인의 경우, @kakao 가 아닌 다른 이메일로도 kakao 가입이 가능하기 때문에, 소셜 로그인 시 중복 이메일이 등록될 수 있습니다.

<img width="610" alt="스크린샷 2024-07-27 오전 5 02 35" src="https://github.com/user-attachments/assets/3898e66a-08bc-402b-b59e-86475264a28d">

따라서 현재 로그인한 회원의 정보를 가져오는 `ApiMember` 에서 이메일 말고도 회원 id를 받아와서 memberRepository 에서 쿼리 조회 시 2가지 이상의 결과값이 나오지 않게 처리했습니다.

<img width="610" alt="스크린샷 2024-07-27 오전 5 02 17" src="https://github.com/user-attachments/assets/f44b3f4f-fc40-49fd-9e1f-512a63b98a99">

closes #64
