### PR TITLE
이미지 업로드 관련 예외처리 로직 추가

### DIFF
--- a/src/main/java/com/chzzk/cushion/global/exception/ErrorCode.java
+++ b/src/main/java/com/chzzk/cushion/global/exception/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
     FILE_SIZE_EXCEEDED(BAD_REQUEST, "파일 크기가 초과되었습니다."),
     EMPTY_JWT_TOKEN(BAD_REQUEST, "토큰 값이 존재하지 않습니다."),
     INVALID_RELATIONSHIP(BAD_REQUEST, "잘못된 관계 입력입니다."),
+    UPLOAD_FILES_SIZE_EXCEEDED(BAD_REQUEST, "업로드할 수 있는 파일 개수를 초과했습니다."),
+    NOT_UPLOAD_FILES(BAD_REQUEST, "파일이 업로드되지 않았습니다."),
 
     // 401
     MISMATCHED_EMAIL_OR_PASSWORD(UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),

--- a/src/main/java/com/chzzk/cushion/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chzzk/cushion/global/exception/GlobalExceptionHandler.java
@@ -9,11 +9,13 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.chzzk.cushion.global.exception.ErrorCode.FILE_SIZE_EXCEEDED;
+import static com.chzzk.cushion.global.exception.ErrorCode.NOT_UPLOAD_FILES;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Slf4j
@@ -49,5 +51,11 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
         log.error("exception message = {}", e.getMessage());
         return ErrorResponse.from(FILE_SIZE_EXCEEDED.getHttpStatus(), e.getMessage());
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    public ErrorResponse handleMultipartException(MultipartException e) {
+        log.error("exception message = {}", e.getMessage());
+        return ErrorResponse.from(NOT_UPLOAD_FILES.getHttpStatus(), NOT_UPLOAD_FILES.getMessage());
     }
 }

--- a/src/main/java/com/chzzk/cushion/style/domain/ClovaOcrApiExecutor.java
+++ b/src/main/java/com/chzzk/cushion/style/domain/ClovaOcrApiExecutor.java
@@ -81,7 +81,7 @@ public class ClovaOcrApiExecutor {
         } else if (Objects.equals(contentType, "image/tiff")) {
             image.put("format", "tiff");
         }
-        image.put("name", "demo");
+        image.put("name", multipartFile.getName());
 
         images.add(image);
 

--- a/src/main/java/com/chzzk/cushion/style/presentation/ExtractConversationController.java
+++ b/src/main/java/com/chzzk/cushion/style/presentation/ExtractConversationController.java
@@ -1,5 +1,7 @@
 package com.chzzk.cushion.style.presentation;
 
+import com.chzzk.cushion.global.exception.CushionException;
+import com.chzzk.cushion.global.exception.ErrorCode;
 import com.chzzk.cushion.style.application.ExtractConversationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,10 +13,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Arrays;
 import java.util.List;
 
-@Slf4j
 @Tag(name = "clova", description = "CLOVA 관련 API")
 @RequestMapping("/ocr")
 @RestController
@@ -26,7 +26,9 @@ public class ExtractConversationController {
     @Operation(summary = "OCR로 대화 내용 추출", description = "OCR을 이용해 이미지 속 대화 내용을 추출합니다.")
     @PostMapping
     public String extractConversation(@RequestPart("file") List<MultipartFile> multipartFiles) {
-        log.info("size = {}, filesArray = {}", multipartFiles.size(), Arrays.toString(multipartFiles.toArray()));
+        if (multipartFiles.size() > 3) {
+            throw new CushionException(ErrorCode.UPLOAD_FILES_SIZE_EXCEEDED);
+        }
         return extractConversationService.extractConversation(multipartFiles);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 이미지를 업로드하지 않은 경우 발생하는 예외 핸들링
- [x] 이미지 업로드할 수 있는 크기를 넘은 경우 발생하는 예외 핸들링

## 💡 자세한 설명
이미지 업로드 관련 예외처리 로직을 추가했습니다.

closes #54 
