### PR TITLE
채팅방 생성 후 응답 변경

### DIFF
--- a/src/main/java/com/chzzk/cushion/chatroom/application/ChatRoomService.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/application/ChatRoomService.java
@@ -11,6 +11,7 @@ import com.chzzk.cushion.chatroom.dto.ChatRoomResponse.ChatRoomDetailResponse;
 import com.chzzk.cushion.chatroom.dto.ChatRoomRequest.ChatRoomCreateRequest;
 import com.chzzk.cushion.chatroom.dto.ChatRoomRequest.ChatRoomDeleteRequest;
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse;
+import com.chzzk.cushion.chatroom.dto.ChatRoomResponse.ChatRoomSimpleResponse;
 import com.chzzk.cushion.chatroom.dto.MessageDto.MessageRequest;
 import com.chzzk.cushion.global.exception.CushionException;
 import com.chzzk.cushion.member.domain.Member;
@@ -31,7 +32,7 @@ public class ChatRoomService {
     private final MessageRepository messageRepository;
 
     @Transactional
-    public ChatRoomDetailResponse create(ChatRoomCreateRequest chatRoomCreateRequest, ApiMember apiMember) {
+    public ChatRoomSimpleResponse create(ChatRoomCreateRequest chatRoomCreateRequest, ApiMember apiMember) {
         // 멤버 검증
         Member member = apiMember.toMember(memberRepository);
 
@@ -39,7 +40,7 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomCreateRequest.toEntity(member, chatRoomTitle);
 
         chatRoomRepository.save(chatRoom);
-        return ChatRoomDetailResponse.fromEntity(chatRoom, chatRoom.getMessages());
+        return ChatRoomSimpleResponse.fromEntity(chatRoom);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/chzzk/cushion/chatroom/dto/ChatRoomResponse.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/dto/ChatRoomResponse.java
@@ -80,4 +80,36 @@ public class ChatRoomResponse { // TODO : DTO 통합
                     .build();
         }
     }
+
+    @Schema(description = "채팅방 생성 후 조회 응답")
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class ChatRoomSimpleResponse {
+
+        @Schema(description = "채팅방 ID", example = "1")
+        private long roomId;
+
+        @Schema(description = "사용자 이름", example = "최진호")
+        private String userName;
+
+        @Schema(description = "상대방 이름", example = "김철수")
+        private String partnerName;
+
+        @Schema(description = "상대방 관계", example = "동료")
+        private String relationship;
+
+        @Schema(description = "채팅방 생성일", example = "2024/05/30")
+        private LocalDate createdAt;
+
+        public static ChatRoomSimpleResponse fromEntity(ChatRoom chatRoom) {
+            return ChatRoomSimpleResponse.builder()
+                    .roomId(chatRoom.getId())
+                    .userName(chatRoom.getMember().getRealName())
+                    .partnerName(chatRoom.getPartnerName())
+                    .relationship(chatRoom.getPartnerRel().getLabel())
+                    .createdAt(chatRoom.getCreatedAt() == null ? null : chatRoom.getCreatedAt().toLocalDate())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/chzzk/cushion/chatroom/presentation/ChatRoomController.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/presentation/ChatRoomController.java
@@ -3,10 +3,10 @@ package com.chzzk.cushion.chatroom.presentation;
 import com.chzzk.cushion.chatroom.application.ChatRoomService;
 import com.chzzk.cushion.chatroom.dto.ChatRoomRequest.ChatRoomUpdateRequest;
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse.ChatRoomDetailResponse;
-import com.chzzk.cushion.chatroom.dto.ChatRoomRequest;
 import com.chzzk.cushion.chatroom.dto.ChatRoomRequest.ChatRoomCreateRequest;
 import com.chzzk.cushion.chatroom.dto.ChatRoomRequest.ChatRoomDeleteRequest;
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse;
+import com.chzzk.cushion.chatroom.dto.ChatRoomResponse.ChatRoomSimpleResponse;
 import com.chzzk.cushion.chatroom.dto.MessageDto.MessageRequest;
 import com.chzzk.cushion.global.utils.AuthPrincipal;
 import com.chzzk.cushion.member.dto.ApiMember;
@@ -28,7 +28,7 @@ public class ChatRoomController {
 
     @Operation(summary = "채팅방 생성", description = "채팅방을 생성합니다.")
     @PostMapping
-    public ChatRoomDetailResponse createChatRoom(@RequestBody ChatRoomCreateRequest chatRoomCreateRequest,
+    public ChatRoomSimpleResponse createChatRoom(@RequestBody ChatRoomCreateRequest chatRoomCreateRequest,
                                @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         return chatRoomService.create(chatRoomCreateRequest, apiMember);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,7 @@ spring:
   jwt:
     secret: ${JWT_SECRET}
     token:
-      access-expiration-time: 1800000     # 30분
+      access-expiration-time: 3600000     # 1시간
       refresh-expiration-time: 604800000   # 7일
 
 ncp:


### PR DESCRIPTION
## 💡 작업 내용
- [x] 채팅방 생성 후 응답 변경
- [x] jwt 토큰 유효기간 증가

## 💡 자세한 설명
### postman 테스트 완료

프론트 요청에 의해 채팅방 생성 후 응답 시, 기존의 `ChatRoomDetailResponse` 대신 새로 `ChatRoomSimpleResponse` 응답 클래스를 반환하도록 구현했습니다.

```json
{
    "roomId": 2,
    "userName": "실명",
    "partnerName": "포텐데이 관계자",
    "relationship": "상사",
    "createdAt": "2024-07-27"
}
```

closes #67 
