### PR TITLE
채팅방 상세 조회 시 메시지의 생성일 기준으로 내림차순되도록 구현

### DIFF
--- a/src/main/java/com/chzzk/cushion/chatroom/application/ChatRoomService.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/application/ChatRoomService.java
@@ -1,16 +1,14 @@
 package com.chzzk.cushion.chatroom.application;
 
-import static com.chzzk.cushion.global.exception.ErrorCode.NOT_FOUND_CHAT_ROOM_THAT_MEMBER;
-
 import com.chzzk.cushion.chatroom.domain.ChatRoom;
 import com.chzzk.cushion.chatroom.domain.Message;
 import com.chzzk.cushion.chatroom.domain.repository.ChatRoomRepository;
 import com.chzzk.cushion.chatroom.domain.repository.MessageRepository;
-import com.chzzk.cushion.chatroom.dto.ChatRoomRequest.ChatRoomUpdateRequest;
-import com.chzzk.cushion.chatroom.dto.ChatRoomResponse.ChatRoomDetailResponse;
 import com.chzzk.cushion.chatroom.dto.ChatRoomRequest.ChatRoomCreateRequest;
 import com.chzzk.cushion.chatroom.dto.ChatRoomRequest.ChatRoomDeleteRequest;
+import com.chzzk.cushion.chatroom.dto.ChatRoomRequest.ChatRoomUpdateRequest;
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse;
+import com.chzzk.cushion.chatroom.dto.ChatRoomResponse.ChatRoomDetailResponse;
 import com.chzzk.cushion.chatroom.dto.ChatRoomResponse.ChatRoomSimpleResponse;
 import com.chzzk.cushion.chatroom.dto.MessageDto.MessageRequest;
 import com.chzzk.cushion.global.exception.CushionException;
@@ -22,6 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.chzzk.cushion.global.exception.ErrorCode.NOT_FOUND_CHAT_ROOM_THAT_MEMBER;
 
 @Service
 @RequiredArgsConstructor
@@ -83,6 +83,7 @@ public class ChatRoomService {
                 .orElseThrow(() -> new CushionException(NOT_FOUND_CHAT_ROOM_THAT_MEMBER));
 
         List<Message> messages = chatRoom.getMessages();
+        messages.sort((m1, m2) -> m2.getCreatedAt().compareTo(m1.getCreatedAt()));
 
         return ChatRoomDetailResponse.fromEntity(chatRoom, messages);
 
@@ -92,7 +93,7 @@ public class ChatRoomService {
     public void saveMessage(MessageRequest messageRequest, Long roomId, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
         ChatRoom chatRoom = chatRoomRepository.findByIdAndMember(roomId, member)
-                        .orElseThrow(() -> new CushionException(NOT_FOUND_CHAT_ROOM_THAT_MEMBER));
+                .orElseThrow(() -> new CushionException(NOT_FOUND_CHAT_ROOM_THAT_MEMBER));
 
         Message message = messageRequest.toEntity(chatRoom);
         messageRepository.save(message);


### PR DESCRIPTION
## 💡 작업 내용
- [x] 채팅방 상세 조회 시 메시지의 생성일 기준 내림차순 정렬 코드 추가

## 💡 자세한 설명
![image](https://github.com/user-attachments/assets/9df91bdf-909d-42d3-a7b0-e9b7058fe42a)
![image](https://github.com/user-attachments/assets/49c2300e-0c30-4ec1-a087-0627d63da9e8)
채팅방 상세 조회 시 메시지의 생성일 기준 내림차순 정렬되도록 구현했습니다.

closes #71 
