### PR TITLE
채팅방 수정 시 제목에 관계의 라벨이 포함되도록 수정

### DIFF
--- a/src/main/java/com/chzzk/cushion/chatroom/application/ChatRoomService.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/application/ChatRoomService.java
@@ -36,7 +36,7 @@ public class ChatRoomService {
         // 멤버 검증
         Member member = apiMember.toMember(memberRepository);
 
-        String chatRoomTitle = chatRoomCreateRequest.getPartnerName() + "(" + chatRoomCreateRequest.getPartnerRel().getLabel() + ")" + "님과의 쿠션";
+        String chatRoomTitle = "%s(%s)님과의 쿠션".formatted(chatRoomCreateRequest.getPartnerName(), chatRoomCreateRequest.getPartnerRel().getLabel());
         ChatRoom chatRoom = chatRoomCreateRequest.toEntity(member, chatRoomTitle);
 
         chatRoomRepository.save(chatRoom);

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
@@ -58,6 +58,6 @@ public class ChatRoom extends BaseTimeEntity {
     public void updateInfo(String partnerName, Relationship partnerRel) {
         this.partnerName = partnerName;
         this.partnerRel = partnerRel;
-        this.title = partnerName + "(" + partnerRel + ")" + "님과의 쿠션";
+        this.title = partnerName + "(" + partnerRel.getLabel() + ")" + "님과의 쿠션";
     }
 }

--- a/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/chzzk/cushion/chatroom/domain/ChatRoom.java
@@ -58,6 +58,6 @@ public class ChatRoom extends BaseTimeEntity {
     public void updateInfo(String partnerName, Relationship partnerRel) {
         this.partnerName = partnerName;
         this.partnerRel = partnerRel;
-        this.title = partnerName + "(" + partnerRel.getLabel() + ")" + "님과의 쿠션";
+        this.title = "%s(%s)님과의 쿠션".formatted(partnerName, partnerRel.getLabel());
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 채팅방 생성 메서드에서 문자열 조합 로직 개선
- [x] 채팅방 수정 시 제목에 관계의 라벨이 포함되도록 수정
- [x] 채팅방 정보 수정 메서드에서 문자열 조합 로직 개선

## 💡 자세한 설명
<img width="679" alt="스크린샷 2024-07-28 오전 2 54 14" src="https://github.com/user-attachments/assets/dd930a2f-32f8-483a-9b56-b85401591823">
매개변수로 전달된 Relationship 자체를 제목에 포함하지 않고, 라벨을 포함하도록 수정했습니다.

closes #72 
